### PR TITLE
Add ability to rename 'out' directory in do_seg function in prediction_imports.py

### DIFF
--- a/doodleverse_utils/prediction_imports.py
+++ b/doodleverse_utils/prediction_imports.py
@@ -268,7 +268,8 @@ def seg_file2tensor_3band(f, TARGET_SIZE):  # , resize):
 def do_seg(
     f, M, metadatadict, sample_direc, 
     NCLASSES, N_DATA_BANDS, TARGET_SIZE, TESTTIMEAUG, WRITE_MODELMETADATA,
-    OTSU_THRESHOLD
+    OTSU_THRESHOLD,
+    out_dir_name='out'
 ):
 
     if f.endswith("jpg"):
@@ -282,11 +283,6 @@ def do_seg(
         metadatadict["input_file"] = f
         
     # directory to hold the outputs of the models is named 'out' by default
-    out_dir_name = 'out'
-    # get the name of the model from the metadatadict and use it to name the directory to hold the outputs of the models
-    if len(metadatadict['model_weights']) > 0:
-        out_dir_name = metadatadict['model_weights'][0].split(os.sep)[-2]
-    
     # create a directory to hold the outputs of the models, by default name it 'out' or the model name if it exists in metadatadict
     out_dir_path = os.path.normpath(sample_direc + os.sep + out_dir_name)
     if not os.path.exists(out_dir_path):

--- a/doodleverse_utils/prediction_imports.py
+++ b/doodleverse_utils/prediction_imports.py
@@ -280,16 +280,22 @@ def do_seg(
 
     if WRITE_MODELMETADATA:
         metadatadict["input_file"] = f
+        
+    # directory to hold the outputs of the models is named 'out' by default
+    out_dir_name = 'out'
+    # get the name of the model from the metadatadict and use it to name the directory to hold the outputs of the models
+    if len(metadatadict['model_weights']) > 0:
+        out_dir_name = metadatadict['model_weights'][0].split(os.sep)[-2]
+    
+    # create a directory to hold the outputs of the models, by default name it 'out' or the model name if it exists in metadatadict
+    out_dir_path = os.path.normpath(sample_direc + os.sep + out_dir_name)
+    if not os.path.exists(out_dir_path):
+        os.mkdir(out_dir_path)
 
     segfile = os.path.normpath(segfile)
     segfile = segfile.replace(
-        os.path.normpath(sample_direc), os.path.normpath(sample_direc + os.sep + "out")
+        os.path.normpath(sample_direc), os.path.normpath(sample_direc + os.sep + out_dir_name)
     )
-
-    try:
-        os.mkdir(os.path.normpath(sample_direc + os.sep + "out"))
-    except:
-        pass
 
     if WRITE_MODELMETADATA:
         metadatadict["nclasses"] = NCLASSES


### PR DESCRIPTION
[One issue in CoastSeg](https://github.com/SatelliteShorelines/CoastSeg/issues/73) is that all model outputs are saved into a directory named 'out' which mean only one model can be run on a directory of imagery. Coastseg uses doodleverse_utils. predition_imports function `do_seg` to perform segmentations on satellite imagery. By default `do_seg` creates a directory named 'out'.  I modified  `do_seg` to keep the default name of the model output directory to 'out' and allow the user to pass a different name for the model output directory. This should make the code backwards compatible with older versions while still allowing the 'out' directory to be renamed.
