### PR TITLE
Fix precision and recall calculation

### DIFF
--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -32,7 +32,7 @@ import tensorflow as tf
 #=================================================
 def Precision(confusionMatrix): 
     epsilon = 1e-6
-    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
+    precision = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
     return precision  
 
 #=================================================

--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -30,20 +30,21 @@ import numpy as np
 import tensorflow as tf
 
 #=================================================
-def Precision(confusionMatrix):  
-    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
+def Precision(confusionMatrix): 
+    epsilon = 1e-6
+    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
     return precision  
 
 #=================================================
 def Recall(confusionMatrix):
     epsilon = 1e-6
-    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
+    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 1) + epsilon)
     return recall
 
 #=================================================
 def F1Score(confusionMatrix):
-    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
-    recall = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 0)
+    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 0)
+    recall = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
     f1score = 2 * precision * recall / (precision + recall)
     return f1score
 


### PR DESCRIPTION
Precision and recall are calculated along the wrong axis. The confusion matrix has the labels along the rows (axis=0) and predictions along the columns (axis=1). Therefore,

precision = TP / (TP + FP)

recall = TP / (TP + FN)

where TP (true positive), TN (true negative), FP (false positive), FN (false negative).

The precision divisor is the sum of true positives (model correctly predicts positive class) and false positives (model incorrectly predicts a positive class) which would be the sum of axis 0. 

The recall divisor is the sum of true positives (model correctly predicts positive class) and false negatives (model incorrectly predicts the negative class) which would be the sum of axis 1.