### PR TITLE
Transpose confusion matrix to fix precision and recall

### DIFF
--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -30,21 +30,20 @@ import numpy as np
 import tensorflow as tf
 
 #=================================================
-def Precision(confusionMatrix): 
-    epsilon = 1e-6
-    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
+def Precision(confusionMatrix):  
+    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
     return precision  
 
 #=================================================
 def Recall(confusionMatrix):
     epsilon = 1e-6
-    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 1) + epsilon)
+    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
     return recall
 
 #=================================================
 def F1Score(confusionMatrix):
-    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 0)
-    recall = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
+    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
+    recall = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 0)
     f1score = 2 * precision * recall / (precision + recall)
     return f1score
 

--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -78,7 +78,7 @@ def ConfusionMatrix(numClass, imgPredict, Label):
     label = numClass * Label[mask] + imgPredict[mask]  
     count = np.bincount(label, minlength = numClass**2)  
     confusionMatrix = count.reshape(numClass, numClass)  
-    return confusionMatrix
+    return confusionMatrix.T
     
 #=================================================
 def OverallAccuracy(confusionMatrix):  

--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -32,7 +32,7 @@ import tensorflow as tf
 #=================================================
 def Precision(confusionMatrix): 
     epsilon = 1e-6
-    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
+    precision = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
     return precision  
 
 #=================================================

--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -30,20 +30,21 @@ import numpy as np
 import tensorflow as tf
 
 #=================================================
-def Precision(confusionMatrix):  
-    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
+def Precision(confusionMatrix): 
+    epsilon = 1e-6
+    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
     return precision  
 
 #=================================================
 def Recall(confusionMatrix):
     epsilon = 1e-6
-    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
+    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 1) + epsilon)
     return recall
 
 #=================================================
 def F1Score(confusionMatrix):
-    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
-    recall = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 0)
+    precision = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 0)
+    recall = np.diag(confusionMatrix) / confusionMatrix.sum(axis = 1)
     f1score = 2 * precision * recall / (precision + recall)
     return f1score
 

--- a/doodleverse_utils/model_metrics.py
+++ b/doodleverse_utils/model_metrics.py
@@ -32,7 +32,7 @@ import tensorflow as tf
 #=================================================
 def Precision(confusionMatrix): 
     epsilon = 1e-6
-    precision = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
+    recall = np.diag(confusionMatrix) / (confusionMatrix.sum(axis = 0) + epsilon)
     return precision  
 
 #=================================================


### PR DESCRIPTION
Following up on discussion in #29, instead of changing the axis each metric is calculated on, simply transpose the confusion matrix to fix precision and recall calcs. This does change the value reported by `Frequency_Weighted_Intersection_over_Union()` also, but no other metrics. 

I think FWIoU on the transposed confusion matrix is correct though as the frequency is calculated column-wise where each column is now the label, not the prediction.